### PR TITLE
Performance update before 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Village Defense 3 Changelog
 
-### 4.0.0 Release (04.10.2018-13.01.2019)
+### 4.0.0 Release (04.10.2018-14.01.2019)
 **Whole changelog from all beta pre releases**
+* Limited rotten flesh hearts level amount to 30 after this limit you won't receive any more hearts
 * Beta pre 6 (14.12.2018-12.01.2019)
     * Implemented legacy data fixer that will fix inconsistency between original user data and current one (old implementation failure)
     data was wrongly saved without getName() method called. MySQL users are safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### 4.0.0 Release (04.10.2018-14.01.2019)
 **Whole changelog from all beta pre releases**
 * Limited rotten flesh hearts level amount to 30 after this limit you won't receive any more hearts
+* Added zombie idle process to save server load and prevent lag, when game will be in higher waves state system will
+run idle process to halt spawning zombies to x seconds (wave / 15 rounded down) so server will save performance a bit
+* Added zombie spawn limiter, now there won't be more than 750 zombies in wave, any amount above that will be
+decremented to 750 and zombies will gain extra health based on algorithm (zombies this wave - 750 / 15 rounded up)
 * Beta pre 6 (14.12.2018-12.01.2019)
     * Implemented legacy data fixer that will fix inconsistency between original user data and current one (old implementation failure)
     data was wrongly saved without getName() method called. MySQL users are safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 run idle process to halt spawning zombies to x seconds (wave / 15 rounded down) so server will save performance a bit
 * Added zombie spawn limiter, now there won't be more than 750 zombies in wave, any amount above that will be
 decremented to 750 and zombies will gain extra health based on algorithm (zombies this wave - 750 / 15 rounded up)
+* Now if there will be spawned more than 70 zombies and player uses /vda setwave or /vda clear zombie commands
+only each of 3 zombies will spawn lava particles to prevent client lag
 * Beta pre 6 (14.12.2018-12.01.2019)
     * Implemented legacy data fixer that will fix inconsistency between original user data and current one (old implementation failure)
     data was wrongly saved without getName() method called. MySQL users are safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ run idle process to halt spawning zombies to x seconds (wave / 15 rounded down) 
 decremented to 750 and zombies will gain extra health based on algorithm (zombies this wave - 750 / 15 rounded up)
 * Now if there will be spawned more than 70 zombies and player uses /vda setwave or /vda clear zombie commands
 only each of 3 zombies will spawn lava particles to prevent client lag
+* The game will now cleanup all rotten fleshes spawned near 150 blocks from starting location of arena after the game ends
 * Beta pre 6 (14.12.2018-12.01.2019)
     * Implemented legacy data fixer that will fix inconsistency between original user data and current one (old implementation failure)
     data was wrongly saved without getName() method called. MySQL users are safe.

--- a/src/main/java/pl/plajer/villagedefense/arena/Arena.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/Arena.java
@@ -402,6 +402,9 @@ public abstract class Arena extends BukkitRunnable {
           setOptionValue(ArenaOption.WAVE, 1);
           setOptionValue(ArenaOption.TOTAL_KILLED_ZOMBIES, 0);
           setOptionValue(ArenaOption.TOTAL_ORBS_SPENT, 0);
+          setOptionValue(ArenaOption.ZOMBIE_DIFFICULTY_MULTIPLIER, 0);
+          setOptionValue(ArenaOption.ZOMBIE_IDLE_PROCESS, 0);
+          zombieSpawnManager.applyIdle(0);
           if (plugin.getConfigPreferences().getOption(ConfigPreferences.Option.BUNGEE_ENABLED)) {
             for (Player player : plugin.getServer().getOnlinePlayers()) {
               this.addPlayer(player);

--- a/src/main/java/pl/plajer/villagedefense/arena/Arena.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/Arena.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -84,7 +83,7 @@ public abstract class Arena extends BukkitRunnable {
   private final Random random = new Random();
   private final List<Zombie> glitchedZombies = new ArrayList<>();
   private final Map<Zombie, Location> zombieCheckerLocations = new HashMap<>();
-  private final Set<UUID> players = new HashSet<>();
+  private final Set<Player> players = new HashSet<>();
   private ShopManager shopManager;
   private ZombieSpawnManager zombieSpawnManager;
   private ScoreboardManager scoreboardManager;
@@ -569,18 +568,8 @@ public abstract class Arena extends BukkitRunnable {
    *
    * @return set of players in arena
    */
-  public HashSet<Player> getPlayers() {
-    HashSet<Player> list = new HashSet<>();
-    Iterator<UUID> iterator = players.iterator();
-    while (iterator.hasNext()) {
-      UUID uuid = iterator.next();
-      if (Bukkit.getPlayer(uuid) == null) {
-        iterator.remove();
-        Debugger.debug(LogLevel.WARN, "Removed invalid player from arena " + getID() + " (not online?)");
-      }
-      list.add(Bukkit.getPlayer(uuid));
-    }
-    return list;
+  public Set<Player> getPlayers() {
+    return players;
   }
 
   public void teleportToLobby(Player player) {
@@ -877,14 +866,14 @@ public abstract class Arena extends BukkitRunnable {
   }
 
   void addPlayer(Player player) {
-    players.add(player.getUniqueId());
+    players.add(player);
   }
 
   void removePlayer(Player player) {
-    if (player == null || player.getUniqueId() == null) {
+    if (player == null) {
       return;
     }
-    players.remove(player.getUniqueId());
+    players.remove(player);
   }
 
   public List<Player> getPlayersLeft() {

--- a/src/main/java/pl/plajer/villagedefense/arena/Arena.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/Arena.java
@@ -323,7 +323,6 @@ public abstract class Arena extends BukkitRunnable {
               setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, 0);
             }
             setTimer(getTimer() - 1);
-
           } else {
             if (getTimer() <= 0) {
               fighting = true;
@@ -933,9 +932,9 @@ public abstract class Arena extends BukkitRunnable {
 
   void restoreDoors() {
     int i = 0;
-    for (Location location : doorBlocks.keySet()) {
-      Block block = location.getBlock();
-      Byte doorData = doorBlocks.get(location);
+    for (Map.Entry<Location, Byte> entry : doorBlocks.entrySet()) {
+      Block block = entry.getKey().getBlock();
+      Byte doorData = entry.getValue();
       if (plugin.is1_11_R1() || plugin.is1_12_R1()) {
         int id = Material.WOODEN_DOOR.getId();
         block.setTypeIdAndData(id, doorData, false);

--- a/src/main/java/pl/plajer/villagedefense/arena/Arena.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/Arena.java
@@ -40,6 +40,7 @@ import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
 import org.bukkit.entity.IronGolem;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Wolf;
@@ -84,6 +85,7 @@ public abstract class Arena extends BukkitRunnable {
   private final List<Zombie> glitchedZombies = new ArrayList<>();
   private final Map<Zombie, Location> zombieCheckerLocations = new HashMap<>();
   private final Set<Player> players = new HashSet<>();
+  private final List<Item> droppedFleshes = new ArrayList<>();
   private ShopManager shopManager;
   private ZombieSpawnManager zombieSpawnManager;
   private ScoreboardManager scoreboardManager;
@@ -405,6 +407,12 @@ public abstract class Arena extends BukkitRunnable {
           setOptionValue(ArenaOption.ZOMBIE_DIFFICULTY_MULTIPLIER, 0);
           setOptionValue(ArenaOption.ZOMBIE_IDLE_PROCESS, 0);
           zombieSpawnManager.applyIdle(0);
+          for (Item item : droppedFleshes) {
+            if (item != null) {
+              item.remove();
+            }
+          }
+          droppedFleshes.clear();
           if (plugin.getConfigPreferences().getOption(ConfigPreferences.Option.BUNGEE_ENABLED)) {
             for (Player player : plugin.getServer().getOnlinePlayers()) {
               this.addPlayer(player);
@@ -754,6 +762,14 @@ public abstract class Arena extends BukkitRunnable {
       zombie.remove();
     }
     zombies.clear();
+  }
+
+  public void addDroppedFlesh(Item item) {
+    droppedFleshes.add(item);
+  }
+
+  public void removeDroppedFlesh(Item item) {
+    droppedFleshes.remove(item);
   }
 
   public int getZombiesLeft() {

--- a/src/main/java/pl/plajer/villagedefense/arena/ArenaEvents.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/ArenaEvents.java
@@ -23,6 +23,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -34,7 +35,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -105,6 +108,40 @@ public class ArenaEvents implements Listener {
           return;
         }
       }
+    } catch (Exception ex) {
+      new ReportedException(plugin, ex);
+    }
+  }
+
+  @EventHandler
+  public void onItemDrop(ItemSpawnEvent e) {
+    try {
+      if (e.getEntity().getItemStack().getType() != Material.ROTTEN_FLESH) {
+        return;
+      }
+      for (Arena arena : ArenaRegistry.getArenas()) {
+        if (!e.getEntity().getWorld().equals(arena.getStartLocation().getWorld())) {
+          continue;
+        }
+        if (e.getEntity().getLocation().distance(arena.getStartLocation()) > 150) {
+          continue;
+        }
+        arena.addDroppedFlesh(e.getEntity());
+      }
+    } catch (Exception ex) {
+      new ReportedException(plugin, ex);
+    }
+  }
+
+  @Deprecated //should use EntityPickupItemEvent
+  @EventHandler
+  public void onDropPickup(PlayerPickupItemEvent e) {
+    try {
+      Arena arena = ArenaRegistry.getArena(e.getPlayer());
+      if (arena == null) {
+        return;
+      }
+      arena.removeDroppedFlesh(e.getItem());
     } catch (Exception ex) {
       new ReportedException(plugin, ex);
     }

--- a/src/main/java/pl/plajer/villagedefense/arena/ArenaManager.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/ArenaManager.java
@@ -376,7 +376,18 @@ public class ArenaManager {
     try {
       VillageWaveStartEvent villageWaveStartEvent = new VillageWaveStartEvent(arena, arena.getWave());
       Bukkit.getPluginManager().callEvent(villageWaveStartEvent);
-      arena.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, (int) Math.ceil((arena.getPlayers().size() * 0.5) * (arena.getOption(ArenaOption.WAVE) * arena.getOption(ArenaOption.WAVE)) / 2));
+      int zombiesAmount = (int) Math.ceil((arena.getPlayers().size() * 0.5) * (arena.getOption(ArenaOption.WAVE) * arena.getOption(ArenaOption.WAVE)) / 2);
+      if (zombiesAmount > 750) {
+        arena.setOptionValue(ArenaOption.ZOMBIE_DIFFICULTY_MULTIPLIER, (int) Math.ceil((zombiesAmount - 750.0) / 15));
+        Debugger.debug(LogLevel.INFO, "Detected abnormal wave (" + arena.getWave() + ") in arena " + arena.getID() + "! Applying zombie limit and difficulty multiplier to "
+            + arena.getOption(ArenaOption.ZOMBIE_DIFFICULTY_MULTIPLIER));
+        zombiesAmount = 750;
+      }
+      arena.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, zombiesAmount);
+      arena.setOptionValue(ArenaOption.ZOMBIE_IDLE_PROCESS, (int) Math.floor((double) arena.getWave() / 15));
+      if (arena.getOption(ArenaOption.ZOMBIE_IDLE_PROCESS) > 0) {
+        Debugger.debug(LogLevel.INFO, "Spawn idle process initiated for arena " + arena.getID() + " to prevent server overload! Value: " + arena.getOption(ArenaOption.ZOMBIE_IDLE_PROCESS));
+      }
       if (plugin.getConfig().getBoolean("Respawn-After-Wave", true)) {
         ArenaUtils.bringDeathPlayersBack(arena);
       }

--- a/src/main/java/pl/plajer/villagedefense/arena/ArenaRegistry.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/ArenaRegistry.java
@@ -45,7 +45,7 @@ public class ArenaRegistry {
    * Checks if player is in any arena
    *
    * @param player player to check
-   * @return [b]true[/b] when player is in arena, [b]false[/b] if otherwise
+   * @return true when player is in arena, false if otherwise
    */
   public static boolean isInArena(Player player) {
     for (Arena arena : arenas) {

--- a/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_11_R1.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_11_R1.java
@@ -71,7 +71,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
@@ -88,7 +88,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     zombie.setRemoveWhenFarAway(false);
     zombie.getEquipment().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
     zombie.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -108,7 +108,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -119,7 +119,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     BabyZombie fastZombie = new BabyZombie(world);
     fastZombie.setPosition(location.getX(), location.getY(), location.getZ());
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     zombie.setRemoveWhenFarAway(false);
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
@@ -139,7 +139,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -156,7 +156,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.IRON_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.IRON_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -171,7 +171,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     zombie.getEquipment().setHelmetDropChance(0.0F);
     zombie.getEquipment().setItemInMainHandDropChance(0F);
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -189,7 +189,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     zombie.getEquipment().setBoots(new ItemStack(Material.GOLD_BOOTS));
     zombie.getEquipment().setLeggings(new ItemStack(Material.GOLD_LEGGINGS));
     zombie.getEquipment().setChestplate(new ItemStack(Material.GOLD_CHESTPLATE));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -207,7 +207,7 @@ public class ArenaInitializer1_11_R1 extends Arena {
     zombie.getEquipment().setLeggings(new ItemStack(Material.CHAINMAIL_LEGGINGS));
     zombie.getEquipment().setChestplate(new ItemStack(Material.CHAINMAIL_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.CHAINMAIL_HELMET));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);

--- a/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_12_R1.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_12_R1.java
@@ -74,7 +74,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
@@ -91,7 +91,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     zombie.setRemoveWhenFarAway(false);
     zombie.getEquipment().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
     zombie.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -111,7 +111,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -122,7 +122,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     BabyZombie fastZombie = new BabyZombie(world);
     fastZombie.setPosition(location.getX(), location.getY(), location.getZ());
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
     zombie.setRemoveWhenFarAway(false);
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
@@ -142,7 +142,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -159,7 +159,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.IRON_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.IRON_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -174,7 +174,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     zombie.getEquipment().setHelmetDropChance(0.0F);
     zombie.getEquipment().setItemInMainHandDropChance(0F);
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -192,7 +192,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     zombie.getEquipment().setBoots(new ItemStack(Material.GOLD_BOOTS));
     zombie.getEquipment().setLeggings(new ItemStack(Material.GOLD_LEGGINGS));
     zombie.getEquipment().setChestplate(new ItemStack(Material.GOLD_CHESTPLATE));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -210,7 +210,7 @@ public class ArenaInitializer1_12_R1 extends Arena {
     zombie.getEquipment().setLeggings(new ItemStack(Material.CHAINMAIL_LEGGINGS));
     zombie.getEquipment().setChestplate(new ItemStack(Material.CHAINMAIL_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.CHAINMAIL_HELMET));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);

--- a/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_13_R1.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_13_R1.java
@@ -78,7 +78,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
@@ -95,7 +95,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     zombie.setRemoveWhenFarAway(false);
     zombie.getEquipment().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
     zombie.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -115,7 +115,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -126,7 +126,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     BabyZombie fastZombie = new BabyZombie(world);
     fastZombie.setPosition(location.getX(), location.getY(), location.getZ());
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
     zombie.setRemoveWhenFarAway(false);
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
@@ -146,7 +146,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -163,7 +163,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.IRON_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.IRON_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -178,7 +178,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     zombie.getEquipment().setHelmetDropChance(0.0F);
     zombie.getEquipment().setItemInMainHandDropChance(0F);
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -196,7 +196,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     zombie.getEquipment().setBoots(XMaterial.GOLDEN_BOOTS.parseItem());
     zombie.getEquipment().setLeggings(XMaterial.GOLDEN_LEGGINGS.parseItem());
     zombie.getEquipment().setChestplate(XMaterial.GOLDEN_CHESTPLATE.parseItem());
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -214,7 +214,7 @@ public class ArenaInitializer1_13_R1 extends Arena {
     zombie.getEquipment().setLeggings(new ItemStack(Material.CHAINMAIL_LEGGINGS));
     zombie.getEquipment().setChestplate(new ItemStack(Material.CHAINMAIL_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.CHAINMAIL_HELMET));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);

--- a/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_13_R2.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/initializers/ArenaInitializer1_13_R2.java
@@ -78,7 +78,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
@@ -95,7 +95,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     zombie.setRemoveWhenFarAway(false);
     zombie.getEquipment().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
     zombie.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -115,7 +115,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie((Zombie) fastZombie.getBukkitEntity());
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -126,7 +126,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     BabyZombie fastZombie = new BabyZombie(world);
     fastZombie.setPosition(location.getX(), location.getY(), location.getZ());
     Zombie zombie = (Zombie) fastZombie.getBukkitEntity();
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     plugin.getHolidayManager().applyHolidayZombieEffects(zombie);
     zombie.setRemoveWhenFarAway(false);
     world.addEntity(fastZombie, CreatureSpawnEvent.SpawnReason.CUSTOM);
@@ -146,7 +146,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.DIAMOND_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.DIAMOND_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -163,7 +163,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     zombie.getEquipment().setChestplate(new ItemStack(Material.IRON_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.IRON_HELMET));
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
   }
@@ -178,7 +178,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     zombie.getEquipment().setHelmetDropChance(0.0F);
     zombie.getEquipment().setItemInMainHandDropChance(0F);
     zombie.setRemoveWhenFarAway(false);
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -196,7 +196,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     zombie.getEquipment().setBoots(XMaterial.GOLDEN_BOOTS.parseItem());
     zombie.getEquipment().setLeggings(XMaterial.GOLDEN_LEGGINGS.parseItem());
     zombie.getEquipment().setChestplate(XMaterial.GOLDEN_CHESTPLATE.parseItem());
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);
@@ -214,7 +214,7 @@ public class ArenaInitializer1_13_R2 extends Arena {
     zombie.getEquipment().setLeggings(new ItemStack(Material.CHAINMAIL_LEGGINGS));
     zombie.getEquipment().setChestplate(new ItemStack(Material.CHAINMAIL_CHESTPLATE));
     zombie.getEquipment().setHelmet(new ItemStack(Material.CHAINMAIL_HELMET));
-    CreatureUtils.applyHealthBar(zombie);
+    CreatureUtils.applyHealthAttributes(zombie, this);
     this.addZombie(zombie);
 
     super.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, getOption(ArenaOption.ZOMBIES_TO_SPAWN) - 1);

--- a/src/main/java/pl/plajer/villagedefense/arena/managers/ScoreboardManager.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/managers/ScoreboardManager.java
@@ -64,7 +64,7 @@ public class ScoreboardManager {
         user.removeScoreboard();
         return;
       }
-      scoreboard = new GameScoreboard("PL_VD3", "PL_CR", boardTitle);
+      scoreboard = new GameScoreboard("PL_VD4", "PL_CR", boardTitle);
       List<String> lines;
       if (arena.getArenaState() == ArenaState.IN_GAME) {
         lines = LanguageManager.getLanguageList("Scoreboard.Content.Playing" + (arena.isFighting() ? "" : "-Waiting"));

--- a/src/main/java/pl/plajer/villagedefense/arena/managers/ZombieSpawnManager.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/managers/ZombieSpawnManager.java
@@ -32,10 +32,15 @@ public class ZombieSpawnManager {
 
   private Random random;
   private Arena arena;
+  private int localIdleProcess = 0;
 
   public ZombieSpawnManager(Arena arena) {
     this.arena = arena;
     this.random = new Random();
+  }
+
+  public void applyIdle(int idle) {
+    localIdleProcess = idle;
   }
 
   /**
@@ -45,6 +50,14 @@ public class ZombieSpawnManager {
    * on random value and current wave
    */
   public void spawnZombies() {
+    //Idling to ~~save server stability~~ protect against hordes of zombies
+    if (localIdleProcess > 0) {
+      localIdleProcess--;
+      return;
+    } else {
+      applyIdle(arena.getOption(ArenaOption.ZOMBIE_IDLE_PROCESS));
+      //continue spawning
+    }
     int wave = arena.getOption(ArenaOption.WAVE);
     int zombiesToSpawn = arena.getOption(ArenaOption.ZOMBIES_TO_SPAWN);
     if (arena.getZombies() == null || arena.getZombies().size() <= 0) {

--- a/src/main/java/pl/plajer/villagedefense/arena/options/ArenaOption.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/options/ArenaOption.java
@@ -82,7 +82,27 @@ public enum ArenaOption {
    * If value is equal 5 or 15 and wave is enough high special
    * zombie units will be spawned in addition to standard ones.
    */
-  ZOMBIE_SPAWN_COUNTER(0);
+  ZOMBIE_SPAWN_COUNTER(0),
+  /**
+   * Value describes how many seconds zombie spawn system should halt and not spawn any entity.
+   * This value reduces server load and lag preventing spawning hordes at once.
+   * Example when wave is 30 counter will set value to 2 halting zombies spawn for 2 seconds
+   * Algorithm: floor(wave / 15)
+   */
+  ZOMBIE_IDLE_PROCESS(0),
+  /**
+   * Value that describes the multiplier of extra health zombies will receive.
+   * Current health + multiplier.
+   * <p>
+   * Since 4.0.0 there is maximum amount of 750 to spawn in wave.
+   * The more value will be above 750 the stronger zombies will be.
+   * <p>
+   * Zombies amount is based on algorithm: ceil((players * 0.5) * (wave * wave) / 2)
+   * Difficulty multiplier is based on: ceil((ceil((players * 0.5) * (wave * wave) / 2) - 750) / 15)
+   * Example: 12 players in wave 20 will receive 30 difficulty multiplier.
+   * So each zombie will get 30 HP more, harder!
+   */
+  ZOMBIE_DIFFICULTY_MULTIPLIER(0);
 
   private int defaultValue;
 

--- a/src/main/java/pl/plajer/villagedefense/commands/arguments/admin/ClearEntitiesArgument.java
+++ b/src/main/java/pl/plajer/villagedefense/commands/arguments/admin/ClearEntitiesArgument.java
@@ -78,9 +78,14 @@ public class ClearEntitiesArgument {
               sender.sendMessage(registry.getPlugin().getChatManager().colorMessage("Kits.Cleaner.Nothing-To-Clean"));
               return;
             }
+            boolean eachThree = arena.getZombies().size() > 70;
+            int i = 0;
             for (Zombie zombie : arena.getZombies()) {
-              zombie.getWorld().spawnParticle(Particle.LAVA, zombie.getLocation(), 20);
+              if (eachThree && (i % 3) == 0) {
+                zombie.getWorld().spawnParticle(Particle.LAVA, zombie.getLocation(), 20);
+              }
               zombie.remove();
+              i++;
             }
             arena.getZombies().clear();
             arena.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, 0);

--- a/src/main/java/pl/plajer/villagedefense/commands/arguments/admin/SpyChatArgument.java
+++ b/src/main/java/pl/plajer/villagedefense/commands/arguments/admin/SpyChatArgument.java
@@ -20,7 +20,6 @@ package pl.plajer.villagedefense.commands.arguments.admin;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -38,7 +37,7 @@ import pl.plajer.villagedefense.commands.arguments.data.LabeledCommandArgument;
  */
 public class SpyChatArgument {
 
-  private Set<UUID> spyChatters = new HashSet<>();
+  private Set<Player> spyChatters = new HashSet<>();
 
   public SpyChatArgument(ArgumentsRegistry registry) {
     registry.mapArgument("villagedefenseadmin", new LabeledCommandArgument("spychat", "villagedefense.admin.spychat", CommandArgument.ExecutorType.PLAYER,
@@ -46,18 +45,23 @@ public class SpyChatArgument {
             + "&7You will see all messages from these games\n&6Permission: &7villagedefense.admin.spychat")) {
       @Override
       public void execute(CommandSender sender, String[] args) {
-        UUID uuid = ((Player) sender).getUniqueId();
-        if (spyChatters.contains(uuid)) {
-          spyChatters.remove(uuid);
+        Player player = (Player) sender;
+        if (spyChatters.contains(player)) {
+          spyChatters.remove(player);
         } else {
-          spyChatters.add(uuid);
+          spyChatters.add(player);
         }
-        sender.sendMessage(registry.getPlugin().getChatManager().getPrefix() + ChatColor.GREEN + "Game spy chat toggled to " + spyChatters.contains(uuid));
+        sender.sendMessage(registry.getPlugin().getChatManager().getPrefix() + ChatColor.GREEN + "Game spy chat toggled to " + spyChatters.contains(player));
       }
     });
   }
 
   public boolean isSpyChatEnabled(Player player) {
-    return spyChatters.contains(player.getUniqueId());
+    return spyChatters.contains(player);
   }
+
+  public void disableSpyChat(Player player) {
+    spyChatters.remove(player);
+  }
+
 }

--- a/src/main/java/pl/plajer/villagedefense/commands/arguments/admin/arena/SetWaveArgument.java
+++ b/src/main/java/pl/plajer/villagedefense/commands/arguments/admin/arena/SetWaveArgument.java
@@ -63,9 +63,14 @@ public class SetWaveArgument {
             player1.sendMessage(registry.getPlugin().getChatManager().getPrefix() + message);
           }
           if (arena.getZombies() != null) {
+            boolean eachThree = arena.getZombies().size() > 70;
+            int i = 0;
             for (Zombie zombie : arena.getZombies()) {
-              zombie.getWorld().spawnParticle(Particle.LAVA, zombie.getLocation(), 20);
+              if (eachThree && (i % 3) == 0) {
+                zombie.getWorld().spawnParticle(Particle.LAVA, zombie.getLocation(), 20);
+              }
               zombie.remove();
+              i++;
             }
             arena.getZombies().clear();
             arena.setOptionValue(ArenaOption.ZOMBIES_TO_SPAWN, 0);

--- a/src/main/java/pl/plajer/villagedefense/creatures/CreatureUtils.java
+++ b/src/main/java/pl/plajer/villagedefense/creatures/CreatureUtils.java
@@ -28,6 +28,8 @@ import org.bukkit.entity.Zombie;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import pl.plajer.villagedefense.Main;
+import pl.plajer.villagedefense.arena.Arena;
+import pl.plajer.villagedefense.arena.options.ArenaOption;
 import pl.plajer.villagedefense.handlers.language.LanguageManager;
 import pl.plajerlair.core.utils.MinigameUtils;
 
@@ -72,7 +74,15 @@ public class CreatureUtils {
     return o;
   }
 
-  public static void applyHealthBar(Zombie zombie) {
+  /**
+   * Applies health attributes (i.e. health bar (if enabled) and
+   * health multiplier) to target zombie.
+   *
+   * @param zombie zombie to apply attributes for
+   * @param arena  arena to get health multiplier from
+   */
+  public static void applyHealthAttributes(Zombie zombie, Arena arena) {
+    zombie.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(zombie.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue() + arena.getOption(ArenaOption.ZOMBIE_DIFFICULTY_MULTIPLIER));
     if (plugin.getConfig().getBoolean("Simple-Zombie-Health-Bar-Enabled", true)) {
       zombie.setCustomNameVisible(true);
       zombie.setCustomName(MinigameUtils.getProgressBar((int) zombie.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue(),

--- a/src/main/java/pl/plajer/villagedefense/events/Events.java
+++ b/src/main/java/pl/plajer/villagedefense/events/Events.java
@@ -646,7 +646,7 @@ public class Events implements Listener {
         e.setCancelled(true);
         e.getInventory().clear();
         e.getItem().getLocation().getWorld().spawnParticle(Particle.CLOUD, e.getItem().getLocation(), 50, 2, 2, 2);
-        if (!arena.checkLevelUpRottenFlesh()) {
+        if (!arena.checkLevelUpRottenFlesh() || arena.getOption(ArenaOption.ROTTEN_FLESH_LEVEL) >= 30) {
           return;
         }
         for (Player p : arena.getPlayers()) {

--- a/src/main/java/pl/plajer/villagedefense/events/QuitEvent.java
+++ b/src/main/java/pl/plajer/villagedefense/events/QuitEvent.java
@@ -63,6 +63,8 @@ public class QuitEvent implements Listener {
         plugin.getUserManager().saveStatistic(user, stat);
       }
       plugin.getUserManager().removeUser(event.getPlayer());
+
+      plugin.getArgumentsRegistry().getSpyChat().disableSpyChat(event.getPlayer());
     } catch (Exception ex) {
       new ReportedException(plugin, ex);
     }

--- a/src/main/java/pl/plajer/villagedefense/events/spectator/SpectatorItemEvents.java
+++ b/src/main/java/pl/plajer/villagedefense/events/spectator/SpectatorItemEvents.java
@@ -19,7 +19,7 @@
 package pl.plajer.villagedefense.events.spectator;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Set;
 
 import org.bukkit.ChatColor;
 import org.bukkit.World;
@@ -81,7 +81,7 @@ public class SpectatorItemEvents implements Listener {
   private void openSpectatorMenu(World world, Player p) {
     Inventory inventory = plugin.getServer().createInventory(null, MinigameUtils.serializeInt(ArenaRegistry.getArena(p).getPlayers().size()),
         plugin.getChatManager().colorMessage("In-Game.Spectator.Spectator-Menu-Name"));
-    HashSet<Player> players = ArenaRegistry.getArena(p).getPlayers();
+    Set<Player> players = ArenaRegistry.getArena(p).getPlayers();
     for (Player player : world.getPlayers()) {
       if (players.contains(player) && !plugin.getUserManager().getUser(player).isSpectator()) {
         ItemStack skull = CompatMaterialConstants.PLAYER_HEAD_ITEM.clone();


### PR DESCRIPTION
* Limited rotten flesh hearts level amount to 30 after this limit you won't receive any more hearts
* Added zombie idle process to save server load and prevent lag, when game will be in higher waves state system will
run idle process to halt spawning zombies to x seconds (wave / 15 rounded down) so server will save performance a bit
* Added zombie spawn limiter, now there won't be more than 750 zombies in wave, any amount above that will be
decremented to 750 and zombies will gain extra health based on algorithm (zombies this wave - 750 / 15 rounded up)
* Now if there will be spawned more than 70 zombies and player uses /vda setwave or /vda clear zombie commands
only each of 3 zombies will spawn lava particles to prevent client lag
* The game will now cleanup all rotten fleshes spawned near 150 blocks from starting location of arena after the game ends